### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ We already used nested resources to view posts by author, so now let's look at n
 resources :authors, only: [:show, :index] do
   resources :posts, only: [:show, :index, :new]
 end
+resources :posts
 ```
 
 This gives us access to `/authors/:id/posts/new`, and a `new_author_post_path` helper.


### PR DESCRIPTION
Posts needs a create route for the form_for tag and show route for the end of the #create method in the posts controller.

Conversely, the `posts/:id' show route could be avoided if the end of #create, it was `redirect_to author_post_path(@post.author, @post)`, but config/routes.rb would still need to have `resources :posts, only: [:create]` though.